### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ Add to your OpenClaw config (`~/.openclaw/mcp.json`):
 
 </details>
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/debridge-finance-debridge-mcp).
+
 ## Development
 
 ```bash


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/debridge-finance-debridge-mcp).